### PR TITLE
fix: 加载显示的右键菜单顺序，与保存的顺序不一致

### DIFF
--- a/demo-menu/mainwindow.cpp
+++ b/demo-menu/mainwindow.cpp
@@ -84,17 +84,18 @@ void MainWindowPrivate::parseFile()
         hasCustom = false;
         return;
     }
-    for (auto group : groups) {
+    for (int i=0; i<groups.count(); ++i) {
+        QString group = MENUGROUP + QString("%1").arg(i);
         ActionData data;
         setting.beginGroup(group);
-        QString type = setting.value(QString("Type")).toString();
-        if (type == QString("Action")) {
+        QString type = setting.value(MENUTYPE).toString();
+        if (MENUTYPEACTION == type) {
             data.type = ActionType::Action;
-            data.name = setting.value(QString("Name")).toString();
-            data.icon = setting.value(QString("Icon")).toString();
-            data.tips = setting.value(QString("Tips")).toString();
-            data.commd = setting.value(QString("Commd")).toString();
-        } else if (type == QString("Separator")) {
+            data.name = setting.value(MENUNAME).toString();
+            data.icon = setting.value(MENUICON).toString();
+            data.tips = setting.value(MENUTIPS).toString();
+            data.commd = setting.value(MENUCOMMD).toString();
+        } else if (MENUTYPESEPARATOR == type) {
             data.type = ActionType::Separator;
         } else {
             data.type = ActionType::Unknow;

--- a/demo-menu/mainwindow_p.h
+++ b/demo-menu/mainwindow_p.h
@@ -41,17 +41,9 @@
 #define MAINWINDOW_P_H
 
 #include "mainwindow.h"
+#include "../common/dataDefine.h"
 
 #include <private/qwidget_p.h>
-
-enum ActionType { Unknow = 0, Action, Separator};
-struct ActionData{
-    ActionType type;
-    QString name;
-    QString icon;
-    QString tips;
-    QString commd;
-};
 
 class MainWindowPrivate : public QWidgetPrivate
 {


### PR DESCRIPTION
QSetting保存时乱序导致，即文件中保存的组不是按照代码写入顺序进行保存的